### PR TITLE
Parse cast times from span tags

### DIFF
--- a/elastic.py
+++ b/elastic.py
@@ -1353,7 +1353,10 @@ def get_actions(soup, label):
             if node.name in ['br', 'hr', 'a']:
                 break
 
-            if node.name == 'img' and 'actiondark' in node['class'] :
+            if node.name == 'span' and 'action' in node['class']:
+                parts.append(node['title'])
+
+            elif node.name == 'img' and 'actiondark' in node['class']:
                 parts.append(node['alt'])
 
             else:


### PR DESCRIPTION
The actions/cast time information in Archives of Nethys is encoded as icons. The  parsing logic in `get_actions` pulls the cast time string from the **alt** attribute of **img** tags with the **actiondark** class. But at some point Nethys must have changed to using **span** tags with the **action** class.

Here's a sample of the current HTML:

```html
<b>Cast</b>  <span aria-label="Two Actions" class="action action-2" role="img" title="Two Actions"> </span>
```

I've added support for parsing **span** tags like that, while leaving the old logic for **img** tags to support old HTML files and potential inconsistencies in the Archives' HTML.

This should fix issue #1.