### PR TITLE
Include data after semicolons in primary/secondary checks

### DIFF
--- a/elastic.py
+++ b/elastic.py
@@ -799,12 +799,12 @@ def parse_ritual(id: str, soup: BeautifulSoup):
     doc.cost = get_label_text(soup, 'Cost')
     doc.duration = get_label_text(soup, 'Duration')
     doc.heighten = get_heighten(soup)
-    doc.primary_check = get_label_text(soup, 'Primary Check')
+    doc.primary_check = get_label_text(soup, 'Primary Check', '').rstrip(';').strip()
     doc.range = normalize_range(range)
     doc.range_raw = range
     doc.secondary_casters = [c for c in secondary_casters if c.isdigit()] if secondary_casters else None
     doc.secondary_casters_raw = secondary_casters
-    doc.secondary_check = get_label_text(soup, 'Secondary Checks')
+    doc.secondary_check = get_label_text(soup, 'Secondary Checks', '').rstrip(';').strip()
     doc.target = get_label_text(soup, 'Target(s)')
     doc.trait = normalize_traits(traits)
     doc.trait_raw = traits


### PR DESCRIPTION
A primary/secondary checks for rituals include semicolons in the text, but the `get_label_text` logic stops parsing when it hits a semicolon by default. As a result, the rest of the text gets cut off for those values.

For example, the primary check for Abyssal Pact is "Religion (expert; you must be a demon)", but the Nethys Search database currently outputs "Religion (expert".

The Archives of Nethys still often include semicolons at the end of those fields to separate it from other fields on the same line in the rendered webpage, so logic is still needed to right-strip those away.

I've updated the parsing logic for the primary/secondary check fields to not stop at semicolons and right-strip semicolons.