### PR TITLE
Add `hardness_raw`, `hp_raw` and `heighten_structured`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /app.js
 /data
 /elm-stuff
+
+/.history
+/.idea
+/.vscode

--- a/elastic.py
+++ b/elastic.py
@@ -962,7 +962,7 @@ def parse_ritual(id: str, soup: BeautifulSoup):
     doc.duration_raw = duration
 
     doc.heighten = get_heighten(soup)
-    doc.heighten_text = get_heighten_text(soup)
+    doc.heighten_structured = get_heighten_structured(soup)
 
     doc.primary_check = get_label_text(soup, 'Primary Check', '', ';')
     doc.range = normalize_range(range)
@@ -1069,7 +1069,7 @@ def parse_spell(id: str, soup: BeautifulSoup):
     doc.duration_raw = duration
 
     doc.heighten = get_heighten(soup)
-    doc.heighten_text = get_heighten_text(soup)
+    doc.heighten_structured = get_heighten_structured(soup)
 
     doc.mystery = get_label_text(soup, 'Mystery')
     doc.patron_theme = get_label_text(soup, 'Patron Theme')
@@ -1718,20 +1718,25 @@ def get_heighten(soup: BeautifulSoup):
     lines = []
 
     for node in find_heighten_nodes(soup):
-        lines.append(node.text.replace('Heightened (', '').replace(')', ''))
+        lines.append(extract_heighten_key(node))
 
     return lines
 
 
-def get_heighten_text(soup: BeautifulSoup):
+def get_heighten_structured(soup: BeautifulSoup):
     lines = []
 
     for node in find_heighten_nodes(soup):
+        key = extract_heighten_key(node)
         value_text = extract_label_text_from_node(node) or ''
-        text = (node.text + ' ' + value_text).strip()
-        lines.append(text)
+        structured = { "key": key, "effect": value_text }
+        lines.append(structured)
 
     return lines
+
+
+def extract_heighten_key(node: Union[Tag, NavigableString]) -> str:
+    return node.text.replace('Heightened (', '').replace(')', '')
 
 
 def find_heighten_nodes(soup: BeautifulSoup):


### PR DESCRIPTION
Hardness and HP
===

We have some errors with some documents (hazards) where the values are not just numeric. To prevent these errors, we are:

- Adding `hardness_raw` and `hp_raw` with the text values extracted.
- Parsing `hardness` and `hp` as numbers, using an extract number function that will pull out the first float found.

Heighten
===

Currently `heighten` has the heighten level information, but not the effects. I've added `heighten_structured` which will index a list of objects with:
- `key`: string with the heighten key, same as the values of the `heighten` field.
- `effect`: text describing the effect of heightening the spell.

Small refactor of main()
===

- avoid recreating the `parse_functions` map on each document
- show warnings of directories with no parsing function

Types
===

- `[str]` -> `List[str]`
- adding a few missing types